### PR TITLE
Fix visualizer project reference paths on Linux

### DIFF
--- a/src/ConduitR.Visualizer.Core/SourceFileCollector.cs
+++ b/src/ConduitR.Visualizer.Core/SourceFileCollector.cs
@@ -51,7 +51,7 @@ internal static class SourceFileCollector
             var rawProjectPath = parts[1].Trim().Trim('"');
             if (!rawProjectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)) continue;
 
-            projects.Add(Path.GetFullPath(Path.Combine(solutionDirectory, rawProjectPath)));
+            projects.Add(ResolveRelativePath(solutionDirectory, rawProjectPath));
         }
 
         return await ExpandProjectReferencesAsync(projects, cancellationToken).ConfigureAwait(false);
@@ -95,8 +95,17 @@ internal static class SourceFileCollector
             .Descendants("ProjectReference")
             .Select(element => element.Attribute("Include")?.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Select(value => Path.GetFullPath(Path.Combine(projectDirectory, value!)))
+            .Select(value => ResolveRelativePath(projectDirectory, value!))
             .ToArray();
+    }
+
+    private static string ResolveRelativePath(string baseDirectory, string relativePath)
+    {
+        var normalizedPath = relativePath
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+
+        return Path.GetFullPath(Path.Combine(baseDirectory, normalizedPath));
     }
 
     private static bool IsGeneratedOrBuildOutput(string sourcePath)

--- a/tests/ConduitR.Tests/VisualizerTests.cs
+++ b/tests/ConduitR.Tests/VisualizerTests.cs
@@ -64,6 +64,78 @@ public sealed class VisualizerTests
     }
 
     [Fact]
+    public async Task Scanner_resolves_project_references_with_backslash_paths()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "conduitr-visualizer-tests", Guid.NewGuid().ToString("N"));
+        var appDirectory = Path.Combine(root, "App");
+        var libDirectory = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(appDirectory);
+        Directory.CreateDirectory(libDirectory);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(appDirectory, "App.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup>
+                    <ProjectReference Include="..\Lib\Lib.csproj" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(appDirectory, "Request.cs"),
+                """
+                using ConduitR.Abstractions;
+
+                public sealed record CreateOrder : IRequest<CreateOrderResult>;
+                public sealed record CreateOrderResult;
+                public sealed class CreateOrderHandler : IRequestHandler<CreateOrder, CreateOrderResult>
+                {
+                    public ValueTask<CreateOrderResult> Handle(CreateOrder request, CancellationToken cancellationToken)
+                    {
+                        return ValueTask.FromResult(new CreateOrderResult());
+                    }
+                }
+                """);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(libDirectory, "Lib.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk" />
+                """);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(libDirectory, "Behavior.cs"),
+                """
+                using ConduitR.Abstractions;
+
+                public sealed class TestBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+                    where TRequest : IRequest<TResponse>
+                {
+                    public ValueTask<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+                    {
+                        return next();
+                    }
+                }
+                """);
+
+            var scanner = new ConduitSolutionScanner();
+            var flow = await scanner.ScanAsync(Path.Combine(appDirectory, "App.csproj"));
+
+            Assert.Contains(flow.Diagnostics, diagnostic => diagnostic.Message == "Scanned 2 C# source files.");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task Report_writer_creates_mermaid_diagram_artifacts()
     {
         var outputDirectory = Path.Combine(Path.GetTempPath(), "conduitr-visualizer-tests", Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
## Summary
- Normalize MSBuild project paths before resolving solution and `ProjectReference` paths.
- Fixes CI on Ubuntu where backslash-separated project references were not followed, leaving built-in visualizer behavior class locations unresolved.
- Adds a regression test with a backslash `ProjectReference` path.

## Validation
- `dotnet test ConduitR.sln -c Release --verbosity minimal`

## Notes
This should unblock the failing `VisualizerTests.Scanner_discovers_sample_web_api_flows` test from the merged visualizer PR.