### PR TITLE
Bump prerelease train to 1.0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             echo "VERSION=$VER" >> $GITHUB_ENV
           elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
             # Prerelease from main
-            BASE="1.0.5"   # <-- bump when you start the next prerelease train
+            BASE="1.0.6"   # <-- bump when you start the next prerelease train
             DATE=$(date -u +%Y%m%dT%H%M)
             SHA=$(git rev-parse --short "$GITHUB_SHA")
             echo "IS_MAIN=true" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -460,17 +460,17 @@ Visualizer package details:
 - [src/ConduitR.Visualizer.Cli](src/ConduitR.Visualizer.Cli/README.md) documents the Visualizer CLI.
 - [src/ConduitR.Visualizer.Core](src/ConduitR.Visualizer.Core/README.md) documents the Visualizer engine.
 - [src/ConduitR.Visualizer.Analyzers](src/ConduitR.Visualizer.Analyzers/README.md) documents Visual Studio/Roslyn handler hints.
-- [docs/release-1.0.5.md](docs/release-1.0.5.md) contains the next Visualizer release notes.
-- [docs/release-1.0.4.md](docs/release-1.0.4.md) contains the latest stable release notes.
+- [docs/release-1.0.5.md](docs/release-1.0.5.md) contains the latest stable release notes.
+- [docs/release-1.0.4.md](docs/release-1.0.4.md) contains the previous stable release notes.
 
 ## Versioning And Releases
 
 ConduitR follows semantic versioning.
 
-- Latest stable: **1.0.4**
-- Next release train: **1.0.5** with ConduitR Visualizer packages.
-- Tags like `v1.0.4` publish stable NuGet packages.
-- Pushes to `main` publish prerelease packages such as `1.0.4-pre.<date>.<sha>`.
+- Latest stable: **1.0.5**
+- Next release train: **1.0.6**.
+- Tags like `v1.0.5` publish stable NuGet packages.
+- Pushes to `main` publish prerelease packages such as `1.0.6-pre.<date>.<sha>`.
 
 See [GitHub Releases](https://github.com/rezabazargan/ConduitR/releases) and [NuGet](https://www.nuget.org/packages/ConduitR) for published versions.
 


### PR DESCRIPTION
## Summary

- Update the GitHub Actions prerelease base from `1.0.5` to `1.0.6`.
- Update README release/version text now that `1.0.5` is the stable release.

## Why

After pushing the `v1.0.5` tag, future pushes to `main` should publish prerelease packages as `1.0.6-pre.<date>.<sha>` instead of continuing the `1.0.5-pre...` train.

## Validation

Docs/workflow-only change; no code path changed.